### PR TITLE
Working well with bulk add and feed API

### DIFF
--- a/.github/workflows/populate-elastic-cloud.yml
+++ b/.github/workflows/populate-elastic-cloud.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install requests python-dotenv elasticsearch
+          pip install requests python-dotenv elasticsearch tqdm
 
       - name: Run main script
         env:


### PR DESCRIPTION
This PR switches over to the feed API. The change allows me to use the transaction ID as the ID of the document in Elastic. This means that if I try and add a duplicated event it will just update it in place instead.

I've changed the ingestion API to use the bulk ingestion API as well. This has massive performance improvements.

Closes #9 
Closes #7 
Closes #5 